### PR TITLE
Update download URL and fix permissions

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -17,4 +17,5 @@ rm /usr/local/bin/LICENSE.TXT /tmp/resilio-sync_freebsd_x64.tar.gz
 sysrc rslsync_enable="YES"
 
 # start the service
+chmod 644 /usr/local/etc/rslsync.conf
 service rslsync start # 2>/dev/null

--- a/post_install.sh
+++ b/post_install.sh
@@ -21,5 +21,4 @@ chmod 755 /usr/
 chmod 755 /usr/local/
 chmod 755 /usr/local/etc/
 chmod 644 /usr/local/etc/rslsync.conf
-ls -alF /usr/local/etc/
-service rslsync start # 2>/dev/null
+service rslsync start

--- a/post_install.sh
+++ b/post_install.sh
@@ -17,5 +17,5 @@ rm /usr/local/bin/LICENSE.TXT /tmp/resilio-sync_freebsd_x64.tar.gz
 sysrc rslsync_enable="YES"
 
 # start the service
-chmod 644 /usr/local/etc/rslsync.conf
+ls -alF /usr/local/etc/
 service rslsync start # 2>/dev/null

--- a/post_install.sh
+++ b/post_install.sh
@@ -9,7 +9,7 @@ mkdir -p /usr/local/bin
 chown rslsync:rslsync /var/db/rslsync
 
 ## install bin
-fetch -o /tmp https://download-cdn.resilio.com/stable/FreeBSD-x64/resilio-sync_freebsd_x64.tar.gz
+fetch -o /tmp https://download-cdn.resilio.com/stable/freebsd/x64/0/resilio-sync_freebsd_x64.tar.gz
 tar xvf /tmp/resilio-sync_freebsd_x64.tar.gz -C /usr/local/bin/
 rm /usr/local/bin/LICENSE.TXT /tmp/resilio-sync_freebsd_x64.tar.gz
 

--- a/post_install.sh
+++ b/post_install.sh
@@ -17,5 +17,7 @@ rm /usr/local/bin/LICENSE.TXT /tmp/resilio-sync_freebsd_x64.tar.gz
 sysrc rslsync_enable="YES"
 
 # start the service
+find -type d /usr/local/etc -exec chmod 755 {} \;
+chmod 644 /usr/local/etc/rslsync.conf
 ls -alF /usr/local/etc/
 service rslsync start # 2>/dev/null

--- a/post_install.sh
+++ b/post_install.sh
@@ -11,10 +11,10 @@ chown rslsync:rslsync /var/db/rslsync
 ## install bin
 fetch -o /tmp https://download-cdn.resilio.com/stable/freebsd/x64/0/resilio-sync_freebsd_x64.tar.gz
 tar xvf /tmp/resilio-sync_freebsd_x64.tar.gz -C /usr/local/bin/
-rm -f /usr/local/bin/LICENSE.TXT /tmp/resilio-sync_freebsd_x64.tar.gz
+rm /usr/local/bin/LICENSE.TXT /tmp/resilio-sync_freebsd_x64.tar.gz
 
 # enable the service
 sysrc rslsync_enable="YES"
 
 # start the service
-service rslsync start 2>/dev/null
+service rslsync start # 2>/dev/null

--- a/post_install.sh
+++ b/post_install.sh
@@ -17,7 +17,9 @@ rm /usr/local/bin/LICENSE.TXT /tmp/resilio-sync_freebsd_x64.tar.gz
 sysrc rslsync_enable="YES"
 
 # start the service
-find -type d /usr/local/etc -exec chmod 755 {} \;
+chmod 755 /usr/
+chmod 755 /usr/local/
+chmod 755 /usr/local/etc/
 chmod 644 /usr/local/etc/rslsync.conf
 ls -alF /usr/local/etc/
 service rslsync start # 2>/dev/null

--- a/post_install.sh
+++ b/post_install.sh
@@ -11,7 +11,7 @@ chown rslsync:rslsync /var/db/rslsync
 ## install bin
 fetch -o /tmp https://download-cdn.resilio.com/stable/freebsd/x64/0/resilio-sync_freebsd_x64.tar.gz
 tar xvf /tmp/resilio-sync_freebsd_x64.tar.gz -C /usr/local/bin/
-rm /usr/local/bin/LICENSE.TXT /tmp/resilio-sync_freebsd_x64.tar.gz
+rm -f /usr/local/bin/LICENSE.TXT /tmp/resilio-sync_freebsd_x64.tar.gz
 
 # enable the service
 sysrc rslsync_enable="YES"


### PR DESCRIPTION
It seems the download URL has changed, and upon unzipping the file/folder permissions are wrong (700 and 600). These updates change to the correct download URL, and change the permissions on the config file before starting the service.

Tested on TrueNAS-13.0-U6.1